### PR TITLE
Filtered Result Displays Results Horizontally Next to One Another

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,11 @@ function filterSelection(c) {
   if (c == "all") c = "";
   for (i = 0; i < x.length; i++) {
     fruitRemoveClass(x[i], "show");
-    if (x[i].className.indexOf(c) > -1) fruitAddClass(x[i], "show");
+    x[i].parentElement.classList.add('d-none')
+    if (x[i].className.indexOf(c) > -1) {
+      fruitAddClass(x[i], "show")
+      x[i].parentElement.classList.remove("d-none")
+    };
   }
 }
 

--- a/shop.html
+++ b/shop.html
@@ -156,7 +156,7 @@
             </div>
           </div>
         </div>
-        <div class="col-md-4 col-sm-6 d-none d-md-block">
+        <div class="col-md-4 col-sm-6">
           <div class="card filterDiv apricot">
             <div class="card-body">
               <img class="card-img-top" src=".//img/products/apricot 2.jpg" alt="">


### PR DESCRIPTION
## Summary Of Changes
Filtered results now display all products (fruits) horizontally next to each other [however still terminating at 3 products per line] as opposed to viewing the filtered results in a vertical [top-to-bottom] manner. 